### PR TITLE
couchbase [BREAKING CHANGE]: TLS support

### DIFF
--- a/cmos-exporter.yml
+++ b/cmos-exporter.yml
@@ -1,4 +1,4 @@
-couchbase_host: localhost
+couchbase_connection_string: couchbase://localhost
 couchbase_username: Administrator
 couchbase_password: password
 fake_collections: true

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -25,33 +25,39 @@ import (
 )
 
 type Config struct {
-	CouchbaseHost           string   `mapstructure:"couchbase_host"`
-	CouchbaseManagementPort int      `mapstructure:"couchbase_management_port"`
-	CouchbaseUsername       string   `mapstructure:"couchbase_username"`
-	CouchbasePassword       string   `mapstructure:"couchbase_password"`
-	CouchbaseSSL            bool     `mapstructure:"couchbase_ssl"`
-	Bind                    string   `mapstructure:"bind"`
-	FakeCollections         bool     `mapstructure:"fake_collections"`
-	LogLevel                LogLevel `mapstructure:"log_level"`
+	CouchbaseConnectionString      string   `mapstructure:"couchbase_connection_string"`
+	CouchbaseCACertFile            string   `mapstructure:"couchbase_ca_cert_file"`
+	CouchbaseClientCertFile        string   `mapstructure:"couchbase_client_cert_file"`
+	CouchbaseClientKeyFile         string   `mapstructure:"couchbase_client_key_file"`
+	CouchbaseUsername              string   `mapstructure:"couchbase_username"`
+	CouchbasePassword              string   `mapstructure:"couchbase_password"`
+	InsecureCouchbaseSkipTLSVerify bool     `mapstructure:"insecure_couchbase_skip_tls_verify"`
+	Bind                           string   `mapstructure:"bind"`
+	FakeCollections                bool     `mapstructure:"fake_collections"`
+	LogLevel                       LogLevel `mapstructure:"log_level"`
 }
 
 func init() {
-	pflag.StringP("couchbase_host", "h", "localhost", "hostname of Couchbase Server")
-	pflag.IntP("couchbase_management_port", "p", 8091, "management port of Couchbase Server")
+	pflag.StringP("couchbase_connection_string", "h", "couchbase://localhost", "connection string to Couchbase Server - format `couchbase[s]://host,host2`")
 	pflag.StringP("couchbase_user", "u", "Administrator", "username to connect to - must be Read-Only Admin")
 	pflag.StringP("couchbase_password", "P", "", "password to use")
-	pflag.BoolP("couchbase_ssl", "s", false, "whether to require TLS")
+	pflag.String("couchbase_ca_cert_file", "", "path to CA certificate to verify Couchbase Server cert - omit to use system cert pool")
+	pflag.String("couchbase_client_cert_file", "", "path to client certificate to authenticate with")
+	pflag.String("couchbase_client_key_file", "", "path to key for the client certificate")
+	pflag.BoolP("insecure_couchbase_skip_tls_verify", "s", false, "skip verifying TLS certificates (insecure!)")
 	pflag.StringP("bind", "b", ":9091", "host:port to serve on")
 	pflag.Bool("fake_collections", false, "whether to add scope/collection labels to metrics that use them")
 	pflag.StringP("log_level", "l", "info", "level to log at")
 }
 
 func (c Config) MarshalLogObject(enc zapcore.ObjectEncoder) error {
-	enc.AddString("CouchbaseHost", c.CouchbaseHost)
-	enc.AddInt("CouchbaseManagementPort", c.CouchbaseManagementPort)
+	enc.AddString("CouchbaseConnectionString", c.CouchbaseConnectionString)
 	enc.AddString("CouchbaseUsername", "<ud>"+c.CouchbaseUsername+"</ud>")
 	enc.AddString("CouchbasePassword", "[PRIVATE]")
-	enc.AddBool("CouchbaseSSL", c.CouchbaseSSL)
+	enc.AddString("CouchbaseCACertFile", c.CouchbaseCACertFile)
+	enc.AddString("CouchbaseClientCertFile", c.CouchbaseClientCertFile)
+	enc.AddString("CouchbaseClientKeyFile", c.CouchbaseClientKeyFile)
+	enc.AddBool("InsecureCouchbaseSkipTLSVerify", c.InsecureCouchbaseSkipTLSVerify)
 	enc.AddString("Bind", c.Bind)
 	enc.AddBool("FakeCollections", c.FakeCollections)
 	enc.AddString("LogLevel", string(c.LogLevel))
@@ -59,8 +65,7 @@ func (c Config) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 }
 
 func Read(path string) (*Config, error) {
-	viper.SetDefault("couchbase_host", "localhost")
-	viper.SetDefault("couchbase_management_port", 8091)
+	viper.SetDefault("couchbase_connection_string", "couchbase://localhost")
 	viper.SetDefault("bind", ":9091")
 	viper.SetDefault("fake_collections", true)
 	viper.SetDefault("log_level", "info")

--- a/pkg/couchbase/interface.go
+++ b/pkg/couchbase/interface.go
@@ -15,7 +15,11 @@
 
 package couchbase
 
-import "github.com/couchbase/tools-common/cbrest"
+import (
+	"crypto/tls"
+
+	"github.com/couchbase/tools-common/cbrest"
+)
 
 type NodeCommon interface {
 	Close() error
@@ -24,4 +28,5 @@ type NodeCommon interface {
 	GetServicePort(svc cbrest.Service) (int, error)
 	HasService(svc cbrest.Service) (bool, error)
 	Hostname() string
+	TLSConfig() *tls.Config
 }

--- a/pkg/metrics/memcached/memcached.go
+++ b/pkg/metrics/memcached/memcached.go
@@ -357,7 +357,12 @@ func NewMemcachedMetrics(logger *zap.Logger, node couchbase.NodeCommon, metricSe
 	}
 	hostPort := net.JoinHostPort(node.Hostname(), strconv.Itoa(kvPort))
 	logger.Debug("Connecting to", zap.String("hostPort", hostPort))
-	mc, err := memcached.Connect("tcp", hostPort)
+	var mc *memcached.Client
+	if tlsConfig := node.TLSConfig(); tlsConfig != nil {
+		mc, err = memcached.ConnectTLS("tcp", hostPort, tlsConfig)
+	} else {
+		mc, err = memcached.Connect("tcp", hostPort)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/tools/testing/cmos-exporter.yml
+++ b/tools/testing/cmos-exporter.yml
@@ -1,4 +1,5 @@
-couchbase_host: localhost
+couchbase_connection_string: couchbases://localhost
+insecure_couchbase_skip_tls_verify: true
 couchbase_username: Administrator
 couchbase_password: password
 fake_collections: true


### PR DESCRIPTION
Adds TLS support, including client certificates.

BREAKING CHANGES:
* Configuration schema - replaces `couchbase_host` and `couchbase_management_port` with `couchbase_connection_string`
  * note: multiple hosts will be accepted but only the first will be used
* Adds one new method to `couchbase.NodeCommon`, `TLSConfig() *tls.Config`

Tasks:

- [ ] verify it works - smoke tests will use TLS
- [ ] verify mTLS works

Fixes #16